### PR TITLE
TypeScript rules

### DIFF
--- a/src/plugin/configs/typescript.ts
+++ b/src/plugin/configs/typescript.ts
@@ -18,7 +18,7 @@ export default defineConfig(
       '@typescript-eslint/no-empty-object-type': 'error',
       '@typescript-eslint/interface-name-prefix': 'off',
       '@typescript-eslint/explicit-module-boundary-types': 'off',
-      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-explicit-any': 'error',
       '@typescript-eslint/explicit-function-return-type': [
         'error',
         {

--- a/src/plugin/configs/typescript.ts
+++ b/src/plugin/configs/typescript.ts
@@ -48,6 +48,7 @@ export default defineConfig(
           format: ['PascalCase', 'UPPER_CASE'],
         },
       ],
+      '@typescript-eslint/consistent-type-imports': 'error',
     },
   },
 );


### PR DESCRIPTION
- set `@typescript-eslint/no-explicit-any` to error
- set `@typescript-eslint/consistent-type-imports` to error